### PR TITLE
Shopify-641: fixed quantities to match current stock at shopify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Fixed
 - empty cart after registering a new customer
+- quantities for products that changed at Shopify
 
 ## [2.1.0] - 2019-02-18
 ### Removed

--- a/extension/helper/cart.js
+++ b/extension/helper/cart.js
@@ -89,7 +89,7 @@ function getLineItemIdsWithQuantityErrors (lineItems) {
     Object.entries(lineItems[itemId]).forEach(([errorType, errors]) => {
       const quantityError = errors.find(error => error.code === 'not_enough_in_stock' &&
         error.options &&
-        error.options.remaining >= 0
+        error.options.hasOwnProperty('remaining')
       )
       if (quantityError) {
         itemsToUpdate.push({ id: parseInt(itemId), availableQuantity: quantityError.options.remaining })
@@ -114,14 +114,14 @@ async function fixCheckoutQuantities (checkoutCartItems, itemsToUpdate, error, c
 
   // fix quantities first, to not mess with index
   for (let item of itemsToUpdate) {
-    if (item.availableQuantity !== 0) {
+    if (item.availableQuantity > 0) {
       checkoutCartItems[item.id].quantity = item.availableQuantity
       delete error.errors.line_items[item.id]
     }
   }
   // remove not available
   for (let item of itemsToUpdate) {
-    if (item.availableQuantity === 0) {
+    if (item.availableQuantity <= 0) {
       checkoutCartItems.splice(item.id, 1)
       delete error.errors.line_items[item.id]
     }

--- a/extension/helper/cart.js
+++ b/extension/helper/cart.js
@@ -67,9 +67,9 @@ const handleCartError = async (err, checkoutCartItems, cartId, context) => {
     return errorMessages
   }
 
-  const itemsToDelete = getOutOfStockLineItemIds(err.errors.line_items).sort((a, b) => b - a)
-  if (itemsToDelete.length > 0) {
-    await fixCheckoutQuantities(checkoutCartItems, itemsToDelete, err, cartId, context)
+  const itemsToUpdate = getLineItemIdsWithQuantityErrors(err.errors.line_items).sort((a, b) => b - a)
+  if (itemsToUpdate.length > 0) {
+    await fixCheckoutQuantities(checkoutCartItems, itemsToUpdate, err, cartId, context)
 
     return renderErrorItems(err)
   }
@@ -82,38 +82,49 @@ const handleCartError = async (err, checkoutCartItems, cartId, context) => {
  * @param {Object} lineItems
  * @returns {Array}
  */
-function getOutOfStockLineItemIds (lineItems) {
-  const itemsToDelete = []
+function getLineItemIdsWithQuantityErrors (lineItems) {
+  const itemsToUpdate = []
 
   for (let itemId in lineItems) {
     Object.entries(lineItems[itemId]).forEach(([errorType, errors]) => {
-      if (errors.find(error => error.code === 'not_enough_in_stock' &&
+      const quantityError = errors.find(error => error.code === 'not_enough_in_stock' &&
         error.options &&
-        error.options.remaining === 0
-      )) {
-        itemsToDelete.push(parseInt(itemId))
+        error.options.remaining >= 0
+      )
+      if (quantityError) {
+        itemsToUpdate.push({ id: parseInt(itemId), availableQuantity: quantityError.options.remaining })
       }
     })
   }
 
-  return itemsToDelete
+  return itemsToUpdate
 }
 
 /**
  * @param {Array} checkoutCartItems
- * @param {Array} itemsToDelete
+ * @param {Array} itemsToUpdate
  * @param {Error} error
  * @param {Object} error.errors
  * @param {Object} error.errors.line_items
  * @param {number} cartId
  * @param {SDKContext} context
  */
-async function fixCheckoutQuantities (checkoutCartItems, itemsToDelete, error, cartId, context) {
+async function fixCheckoutQuantities (checkoutCartItems, itemsToUpdate, error, cartId, context) {
   const shopifyApiRequest = new ShopifyApiRequest(context.config, context.log)
 
-  for (let itemId of itemsToDelete) {
-    checkoutCartItems.splice(itemId, 1)
-    delete error.errors.line_items[itemId]
+  // fix quantities first, to not mess with index
+  for (let item of itemsToUpdate) {
+    if (item.availableQuantity !== 0) {
+      checkoutCartItems[item.id].quantity = item.availableQuantity
+      delete error.errors.line_items[item.id]
+    }
+  }
+  // remove not available
+  for (let item of itemsToUpdate) {
+    if (item.availableQuantity === 0) {
+      checkoutCartItems.splice(item.id, 1)
+      delete error.errors.line_items[item.id]
+    }
   }
 
   const productData = {
@@ -156,7 +167,7 @@ module.exports = {
   updateCart,
   extractVariantId,
   handleCartError,
-  getOutOfStockLineItemIds,
+  getLineItemIdsWithQuantityErrors,
   getCurrentCartId,
   setCurrentCartId
 }

--- a/extension/test/unit/helper/cart.test.js
+++ b/extension/test/unit/helper/cart.test.js
@@ -243,7 +243,7 @@ describe('Cart Helper', () => {
       )
     })
 
-    it('should return all ids of line items with error "not_enough_in_stock" and remaining quantity >= 0', () => {
+    it('should return all ids of line items with error "not_enough_in_stock"', () => {
       const lineItems = {
         0: {
           quantity: [
@@ -259,12 +259,17 @@ describe('Cart Helper', () => {
           quantity: [
             { code: 'not_enough_in_stock', message: 'some message', options: { remaining: 2 } }
           ]
+        },
+        3: {
+          quantity: [
+            { code: 'not_enough_in_stock', message: 'some message', options: { remaining: -2 } }
+          ]
         }
       }
 
       assert.deepStrictEqual(
         getLineItemIdsWithQuantityErrors(lineItems),
-        [{ 'availableQuantity': 0, 'id': 0 }, { 'availableQuantity': 2, 'id': 2 }]
+        [{ 'availableQuantity': 0, 'id': 0 }, { 'availableQuantity': 2, 'id': 2 }, { 'availableQuantity': -2, 'id': 3 }]
       )
     })
   })

--- a/extension/test/unit/helper/cart.test.js
+++ b/extension/test/unit/helper/cart.test.js
@@ -210,8 +210,8 @@ describe('Cart Helper', () => {
     })
   })
 
-  describe('getOutOfStockLineItemIds', () => {
-    const getOutOfStockLineItemIds = require('../../../../extension/helper/cart').getOutOfStockLineItemIds
+  describe('getLineItemIdsWithQuantityErrors', () => {
+    const getLineItemIdsWithQuantityErrors = require('../../../../extension/helper/cart').getLineItemIdsWithQuantityErrors
 
     it('should return id of line item with error "not_enough_in_stock" and remaining quantity 0', () => {
       const lineItems = {
@@ -223,12 +223,12 @@ describe('Cart Helper', () => {
       }
 
       assert.deepStrictEqual(
-        getOutOfStockLineItemIds(lineItems),
-        [0]
+        getLineItemIdsWithQuantityErrors(lineItems),
+        [{ 'availableQuantity': 0, 'id': 0 }]
       )
     })
 
-    it('should NOT return id of line item with error "not_enough_in_stock" and remaining quantity > 0', () => {
+    it('should ALSO return id of line item with error "not_enough_in_stock" and remaining quantity > 0', () => {
       const lineItems = {
         0: {
           quantity: [
@@ -238,12 +238,12 @@ describe('Cart Helper', () => {
       }
 
       assert.deepStrictEqual(
-        getOutOfStockLineItemIds(lineItems),
-        []
+        getLineItemIdsWithQuantityErrors(lineItems),
+        [{ 'availableQuantity': 2, 'id': 0 }]
       )
     })
 
-    it('should return all id of line item with error "not_enough_in_stock" and remaining quantity = 0', () => {
+    it('should return all ids of line items with error "not_enough_in_stock" and remaining quantity >= 0', () => {
       const lineItems = {
         0: {
           quantity: [
@@ -252,19 +252,19 @@ describe('Cart Helper', () => {
         },
         1: {
           quantity: [
-            { code: 'not_enough_in_stock', message: 'some message', options: { remaining: 2 } }
+            { code: 'some_other_not_relevant_error', message: 'some message', options: { not: 'relevant' } }
           ]
         },
         2: {
           quantity: [
-            { code: 'not_enough_in_stock', message: 'some message', options: { remaining: 0 } }
+            { code: 'not_enough_in_stock', message: 'some message', options: { remaining: 2 } }
           ]
         }
       }
 
       assert.deepStrictEqual(
-        getOutOfStockLineItemIds(lineItems),
-        [0, 2]
+        getLineItemIdsWithQuantityErrors(lineItems),
+        [{ 'availableQuantity': 0, 'id': 0 }, { 'availableQuantity': 2, 'id': 2 }]
       )
     })
   })


### PR DESCRIPTION
# Pull Request Template

## Description

It was not possible to add/remove/update products in the cart, if the stock of at least one products from the cart was not available at Shopify anymore.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md