### PR TITLE
SHOPIFY-708: close in app browser when hitting cart page

### DIFF
--- a/extension/resources/loadScriptFile_v1.js
+++ b/extension/resources/loadScriptFile_v1.js
@@ -19,7 +19,8 @@ module.exports = function (context, input, cb) {
     'login_register': true,
     'account': true,
     'challenge': true,
-    'checkouts': true
+    'checkouts': true,
+    'cart': true
   }
   if (!whitelist[scriptName]) {
     return cb(new ScriptNotWhitelistedError(scriptName))

--- a/extension/resources/scripts/__init.js
+++ b/extension/resources/scripts/__init.js
@@ -6,6 +6,7 @@ window.SGPipelineScript.PAGE_REGISTER = '/account/register'
 window.SGPipelineScript.PAGE_ACCOUNT = '/account'
 window.SGPipelineScript.PAGE_CHALLENGE = '/challenge'
 window.SGPipelineScript.PAGE_CHECKOUTS = '/[0-9]+/checkouts/[0-9a-f]+'
+window.SGPipelineScript.PAGE_CART = '/cart'
 
 /**
  * Definition af a few global storage keys.
@@ -57,6 +58,11 @@ window.SGPipelineScript.__init = function () {
       const history = JSON.parse(window.localStorage.getItem(window.SGPipelineScript.STORAGE_KEY_PAGE_HISTORY))
       history.push('challenge')
       window.localStorage.setItem(window.SGPipelineScript.STORAGE_KEY_PAGE_HISTORY, JSON.stringify(history))
+      break
+    }
+    case this.PAGE_CART: {
+      // load page specific script
+      window.SGAppConnector.loadPipelineScript('cart')
       break
     }
     default: {
@@ -148,6 +154,9 @@ window.SGPipelineScript.getPage = function () {
   } else if (currentLocation.match(this.PAGE_CHECKOUTS.toLowerCase() + '/*$')) {
     // the checkouts/<hash> page
     return this.PAGE_CHECKOUTS
+  } else if (currentLocation.match(this.PAGE_CART.toLowerCase() + '/*$')) {
+    // the checkouts/<hash> page
+    return this.PAGE_CART
   }
 
   // parse the current location and return the last bit of it

--- a/extension/resources/scripts/cart.js
+++ b/extension/resources/scripts/cart.js
@@ -1,0 +1,11 @@
+window.SGPipelineScript.cart = function () {
+  console.log('fire closeInAppBrowser')
+  window.SGAppConnector.sendAppCommand(
+    {
+      c: 'broadcastEvent',
+      p: {
+        event: 'closeInAppBrowser'
+      }
+    }
+  )
+}


### PR DESCRIPTION
# Pull Request Template

## Description

It was possible to break out of the webcheckout in case all products in the cart were not available anymore at shopify and the user clicked on checkout on the app.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I updated the CHANGELOG.md