### PR TITLE
SHOPIFY-745: fixed internal error for unavailable variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- error on app start when unavailable variants are still in the cart
 
 ## [2.2.6] - 2020-02-28
 ### Fixed

--- a/extension/cart/getCart.js
+++ b/extension/cart/getCart.js
@@ -211,7 +211,7 @@ module.exports = async (context, input) => {
 
       /* property */
       // normal products do also have a variant and even an option1 and a value, so we check for the variant_title.
-      if (shopifyProductVariant !== null && item.variant_title !== '') {
+      if (shopifyProductVariant && item.variant_title !== '') {
         let property = new Property()
 
         // shopify can have up to three options (option1 through option3 are always returned by the API)


### PR DESCRIPTION
# Pull Request Template

## Description

An internal error appeared after app launch in case a variant that was not available at Shopify anymore was still in the cart.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md