### PR TITLE
Feat curb 4621 send buyer ip header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- sending the buyer IP along with Storefront API requests as per requirement by Shopify to maintain a consistent checkout experience
 
 ## [3.0.0] - 2024-11-06
 

--- a/extension/cart/addProductsToCart.js
+++ b/extension/cart/addProductsToCart.js
@@ -3,6 +3,7 @@ const ApiFactory = require('../lib/ShopifyApiFactory')
 /**
  * @param {SDKContext} context
  * @param {object} input
+ * @param {SgxsMeta} input.sgxsMeta
  * @param {{ productId: string, quantity: number }[]} input.productsAddedToCart
  * @param {{ id: string, customData: string }[]} input.importedProductsAddedToCart
  * @param {string} input.shopifyCartId
@@ -29,7 +30,7 @@ module.exports = async (context, input) => {
     }
   }).filter(cartLine => !!cartLine) // filter out products with no variant ID
 
-  const storefrontApi = ApiFactory.buildStorefrontApi(context)
+  const storefrontApi = ApiFactory.buildStorefrontApi(context, input.sgxsMeta)
 
   try {
     await storefrontApi.addCartLines(input.shopifyCartId, cartLines)

--- a/extension/cart/deleteProductsFromCart.js
+++ b/extension/cart/deleteProductsFromCart.js
@@ -3,12 +3,13 @@ const ApiFactory = require('../lib/ShopifyApiFactory')
 /**
  * @param {SDKContext} context
  * @param {object} input
+ * @param {SgxsMeta} input.sgxsMeta
  * @param {string[]} input.deleteCartItemIds
  * @param {string} input.shopifyCartId
  * @returns {Promise<{}|{ messages: { code: string, message: string, type: string }[] }>}
  */
 module.exports = async (context, input) => {
-  const storefrontApi = ApiFactory.buildStorefrontApi(context)
+  const storefrontApi = ApiFactory.buildStorefrontApi(context, input.sgxsMeta)
 
   try {
     await storefrontApi.deleteCartLines(input.shopifyCartId, input.deleteCartItemIds)

--- a/extension/cart/fetchShopifyCart.js
+++ b/extension/cart/fetchShopifyCart.js
@@ -3,11 +3,11 @@ const UnknownError = require('../models/Errors/UnknownError')
 
 /**
  * @param {SDKContext} context
- * @param {{ shopifyCartId: string }} input
+ * @param {{ shopifyCartId: string, sgxsMeta: SgxsMeta }} input
  * @returns {Promise<{ shopifyCart: ShopifyCart }>}
  */
-module.exports = async (context, { shopifyCartId }) => {
-  const storefrontApi = ApiFactory.buildStorefrontApi(context)
+module.exports = async (context, { shopifyCartId, sgxsMeta }) => {
+  const storefrontApi = ApiFactory.buildStorefrontApi(context, sgxsMeta)
 
   let shopifyCart
   try {

--- a/extension/cart/initShopifyCart.js
+++ b/extension/cart/initShopifyCart.js
@@ -2,11 +2,11 @@ const ApiFactory = require('../lib/ShopifyApiFactory')
 
 /**
  * @param {Object} context
- * @param {{ storefrontApiCustomerAccessToken: { accessToken: string, expiresAt: string? }? }} input
+ * @param {{ storefrontApiCustomerAccessToken: { accessToken: string, expiresAt: string? }?, sgxsMeta: SgxsMeta }} input
  * @returns {Promise<{ shopifyCartId: string }>}
  */
 module.exports = async (context, input) => {
-  const storefrontApi = ApiFactory.buildStorefrontApi(context)
+  const storefrontApi = ApiFactory.buildStorefrontApi(context, input.sgxsMeta)
   const storage = context.meta.userId ? context.storage.user : context.storage.device
   let shopifyCartId = await storage.get('shopifyCartId')
 

--- a/extension/cart/migrateCartContents.js
+++ b/extension/cart/migrateCartContents.js
@@ -3,12 +3,13 @@ const ApiFactory = require('../lib/ShopifyApiFactory')
 
 /**
  * @param {SDKContext} context
+ * @param {{ sgxsMeta: SgxsMeta }} input
  */
-module.exports = async (context) => {
+module.exports = async (context, { sgxsMeta }) => {
   let deviceCartId = await context.storage.device.get('shopifyCartId')
   const userCartId = await context.storage.user.get('shopifyCartId')
 
-  const storefrontApi = ApiFactory.buildStorefrontApi(context)
+  const storefrontApi = ApiFactory.buildStorefrontApi(context, sgxsMeta)
 
   let deviceCart
   try {

--- a/extension/cart/updateProductsInCart.js
+++ b/extension/cart/updateProductsInCart.js
@@ -3,11 +3,11 @@ const ApiFactory = require('../lib/ShopifyApiFactory')
 
 /**
  * @param {SDKContext} context
- * @param {{ updateCartItems: { cartItemId: string, quantity: number }[] }} input
+ * @param {{ updateCartItems: { cartItemId: string, quantity: number }[], sgxsMeta: SgxsMeta }} input
  * @param {string} input.shopifyCartId
  */
 module.exports = async (context, input) => {
-  const storefrontApi = ApiFactory.buildStorefrontApi(context)
+  const storefrontApi = ApiFactory.buildStorefrontApi(context, input.sgxsMeta)
 
   const updateCartLines = input.updateCartItems.map(item => ({
     id: item.cartItemId,

--- a/extension/lib/ShopifyApiFactory.js
+++ b/extension/lib/ShopifyApiFactory.js
@@ -20,16 +20,19 @@ class ShopifyApiFactory {
 
   /**
    * @param {SDKContext} context
+   * @param {SgxsMeta} sgxsMeta
    * @param {ShopifyApiTokenManager?} tokenManager
    * @param {ShopifyAdminApi?} adminApi
    * @returns {ShopifyStorefrontApi}
    */
-  static buildStorefrontApi (context, tokenManager = null, adminApi = null) {
+  static buildStorefrontApi (context, sgxsMeta, tokenManager = null, adminApi = null) {
+    const { deviceIp } = sgxsMeta || {}
+
     if (storefrontApi) return storefrontApi
 
     if (!tokenManager) tokenManager = this.buildShopifyApiTokenManager(context, adminApi)
 
-    return new ShopifyStorefrontApi(ConfigHelper.getBaseUrl(context.config), tokenManager, context.log)
+    return new ShopifyStorefrontApi(ConfigHelper.getBaseUrl(context.config), deviceIp, tokenManager, context.log)
   }
 
   /**

--- a/extension/typedefs.js
+++ b/extension/typedefs.js
@@ -66,6 +66,12 @@
  */
 
 /**
+ * @typedef {Object} SgxsMeta
+ * @property {string} sessionId
+ * @property {string} deviceIp
+ */
+
+/**
  * @typedef ShopifyCart
  * @property {string} id
  * @property {string} checkoutUrl

--- a/pipelines/shopgate.cart.addProducts.v1.json
+++ b/pipelines/shopgate.cart.addProducts.v1.json
@@ -4,6 +4,7 @@
     "id": "shopgate.cart.addProducts.v1",
     "public": true,
     "input": [
+      {"key": "sgxsMeta", "id": "1", "optional": true},
       {"key": "products", "id": "1080"}
     ],
     "output": [
@@ -21,7 +22,10 @@
         "type": "extension",
         "id": "@shopgate/shopify-cart",
         "path": "@shopgate/shopify-cart/cart/initShopifyCart.js",
-        "input": [{"key": "storefrontApiCustomerAccessToken", "id": "2000", "optional": true}],
+        "input": [
+          {"key": "sgxsMeta", "id": "1", "optional": true},
+          {"key": "storefrontApiCustomerAccessToken", "id": "2000", "optional": true}
+        ],
         "output": [{"key": "shopifyCartId", "id": "2010"}]
       },
       {
@@ -59,6 +63,7 @@
         "id": "@shopgate/shopify-cart",
         "path": "@shopgate/shopify-cart/cart/addProductsToCart.js",
         "input": [
+          {"key": "sgxsMeta", "id": "1", "optional": true},
           {"key": "importedProductsAddedToCart", "id": "100"},
           {"key": "productsAddedToCart", "id": "1080"},
           {"key": "shopifyCartId", "id": "2010"}

--- a/pipelines/shopgate.cart.deleteProducts.v1.json
+++ b/pipelines/shopgate.cart.deleteProducts.v1.json
@@ -4,6 +4,7 @@
     "id": "shopgate.cart.deleteProducts.v1",
     "public": true,
     "input": [
+      {"key": "sgxsMeta", "id":  "100", "optional": true},
       {"key": "CartItemIds", "id": "1080", "optional": true},
       {"key": "cartItemIds", "id": "1081", "optional": true}
     ],
@@ -33,7 +34,10 @@
         "type": "extension",
         "id": "@shopgate/shopify-cart",
         "path": "@shopgate/shopify-cart/cart/initShopifyCart.js",
-        "input": [{"key": "storefrontApiCustomerAccessToken", "id": "2000", "optional": true}],
+        "input": [
+          {"key": "sgxsMeta", "id": "100", "optional": true},
+          {"key": "storefrontApiCustomerAccessToken", "id": "2000", "optional": true}
+        ],
         "output": [{"key": "shopifyCartId", "id": "2010"}]
       },
       {
@@ -41,6 +45,7 @@
         "id": "@shopgate/shopify-cart",
         "path": "@shopgate/shopify-cart/cart/deleteProductsFromCart.js",
         "input": [
+          {"key": "sgxsMeta", "id": "100", "optional": true},
           {"key": "deleteCartItemIds", "id": "1081"},
           {"key": "shopifyCartId", "id": "2010"}
         ],

--- a/pipelines/shopgate.cart.getCart.v1.json
+++ b/pipelines/shopgate.cart.getCart.v1.json
@@ -3,7 +3,9 @@
   "pipeline": {
     "id": "shopgate.cart.getCart.v1",
     "public": true,
-    "input": [],
+    "input": [
+      {"key": "sgxsMeta", "id": "100", "optional": true}
+    ],
     "output": [
       {"key": "isOrderable", "id": "1010"},
       {"key": "isTaxIncluded", "id": "1020"},
@@ -26,13 +28,17 @@
         "type": "extension",
         "id": "@shopgate/shopify-cart",
         "path": "@shopgate/shopify-cart/cart/initShopifyCart.js",
-        "input": [{"key": "storefrontApiCustomerAccessToken", "id": "2000", "optional": true}],
+        "input": [
+          {"key": "sgxsMeta", "id": "100", "optional": true},
+          {"key": "storefrontApiCustomerAccessToken", "id": "2000", "optional": true}
+        ],
         "output": [{"key": "shopifyCartId", "id": "2010"}]
       },
       {
         "id": "afterInitShopifyCart",
         "type": "hook",
         "input": [
+          {"key": "sgxsMeta", "id": "100", "optional": true},
           {"key": "storefrontApiCustomerAccessToken", "id": "2000", "optional": true},
           {"key": "shopifyCartId", "id": "2010"}
         ],
@@ -42,7 +48,10 @@
         "type": "extension",
         "id": "@shopgate/shopify-cart",
         "path": "@shopgate/shopify-cart/cart/fetchShopifyCart.js",
-        "input": [{"key": "shopifyCartId", "id": "2010"}],
+        "input": [
+          {"key": "sgxsMeta", "id": "100", "optional": true},
+          {"key": "shopifyCartId", "id": "2010"}
+        ],
         "output": [{"key": "shopifyCart", "id": "2020"}]
       },
       {
@@ -53,7 +62,7 @@
           {"key": "shopifyCart", "id": "2020"}
         ],
         "output": [
-          {"key": "productIdSets",  "id": "102"}
+          {"key": "productIdSets", "id": "102"}
         ]
       },
       {

--- a/pipelines/shopgate.cart.updateProducts.v1.json
+++ b/pipelines/shopgate.cart.updateProducts.v1.json
@@ -4,6 +4,7 @@
     "id": "shopgate.cart.updateProducts.v1",
     "public": true,
     "input": [
+      {"key": "sgxsMeta", "id": "100", "optional": true},
       {"key": "CartItem", "id": "1010", "optional": true},
       {"key": "cartItems", "id": "1011", "optional": true}
     ],
@@ -31,14 +32,20 @@
         "type": "extension",
         "id": "@shopgate/shopify-cart",
         "path": "@shopgate/shopify-cart/cart/initShopifyCart.js",
-        "input": [{"key": "storefrontApiCustomerAccessToken", "id": "2000", "optional": true}],
+        "input": [
+          {"key": "sgxsMeta", "id": "100", "optional": true},
+          {"key": "storefrontApiCustomerAccessToken", "id": "2000", "optional": true}
+        ],
         "output": [{"key": "shopifyCartId", "id": "2010"}]
       },
       {
         "type": "extension",
         "id": "@shopgate/shopify-cart",
         "path": "@shopgate/shopify-cart/cart/fetchShopifyCart.js",
-        "input": [{"key": "shopifyCartId", "id": "2010"}],
+        "input": [
+          {"key": "sgxsMeta", "id": "100", "optional": true},
+          {"key": "shopifyCartId", "id": "2010"}
+        ],
         "output": [{"key": "shopifyCart", "id": "2020"}]
       },
       {
@@ -111,6 +118,7 @@
         "id": "@shopgate/shopify-cart",
         "path": "@shopgate/shopify-cart/cart/updateProductsInCart.js",
         "input": [
+          {"key": "sgxsMeta", "id": "100", "optional": true},
           {"key": "existingCartItems", "id": "1060"},
           {"key": "updateCartItems", "id": "1011"},
           {"key": "shopifyCartId", "id": "2010"}

--- a/pipelines/shopgate.cart.userLoggedIn.v1.json
+++ b/pipelines/shopgate.cart.userLoggedIn.v1.json
@@ -3,7 +3,9 @@
   "pipeline": {
     "id": "shopgate.cart.userLoggedIn.v1",
     "public": true,
-    "input": [],
+    "input": [
+      {"key": "sgxsMeta", "id": "100", "optional": true}
+    ],
     "output": [],
     "steps": [
       {
@@ -18,14 +20,19 @@
         "description": "Make sure a customer cart exists before migrating.",
         "id": "@shopgate/shopify-cart",
         "path": "@shopgate/shopify-cart/cart/initShopifyCart.js",
-        "input": [{"key": "storefrontApiCustomerAccessToken", "id": "2000"}],
+        "input": [
+          {"key": "sgxsMeta", "id": "100", "optional": true},
+          {"key": "storefrontApiCustomerAccessToken", "id": "2000"}
+        ],
         "output": []
       },
       {
         "type": "extension",
         "id": "@shopgate/shopify-cart",
         "path": "@shopgate/shopify-cart/cart/migrateCartContents.js",
-        "input": [],
+        "input": [
+          {"key": "sgxsMeta", "id": "100", "optional": true}
+        ],
         "output": []
       }
     ]

--- a/pipelines/shopgate.checkout.getUrl.v1.json
+++ b/pipelines/shopgate.checkout.getUrl.v1.json
@@ -3,7 +3,9 @@
   "pipeline": {
     "id": "shopgate.checkout.getUrl.v1",
     "public": true,
-    "input": [],
+    "input": [
+      {"key": "sgxsMeta", "id": "100", "optional": true}
+    ],
     "output": [
       {"key": "url", "id": "1010"}
     ],
@@ -19,14 +21,20 @@
         "type": "extension",
         "id": "@shopgate/shopify-cart",
         "path": "@shopgate/shopify-cart/cart/initShopifyCart.js",
-        "input": [{"key": "storefrontApiCustomerAccessToken", "id": "2000", "optional": true}],
+        "input": [
+          {"key": "sgxsMeta", "id": "100", "optional": true},
+          {"key": "storefrontApiCustomerAccessToken", "id": "2000", "optional": true}
+        ],
         "output": [{"key": "shopifyCartId", "id": "2010"}]
       },
       {
         "type": "extension",
         "id": "@shopgate/shopify-cart",
         "path": "@shopgate/shopify-cart/cart/fetchShopifyCart.js",
-        "input": [{"key": "shopifyCartId", "id": "2010"}],
+        "input": [
+          {"key": "sgxsMeta", "id": "100", "optional": true},
+          {"key": "shopifyCartId", "id": "2010"}
+        ],
         "output": [{"key": "shopifyCart", "id": "2020"}]
       },
       {


### PR DESCRIPTION
# Pull Request Template

## Description

Adds the `Shopify-Storefront-Buyer-IP` header to requests to the Shopify Storefront API as per requirement described at https://shopify.dev/docs/api/usage/authentication?syclid=ctgliif38h1c73dskogg#making-server-side-requests.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md