### PR TITLE
Universal 2025 01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- uses Shopify Storefront API 2025-01
+- uses Shopify REST Admin API 2025-01
+
+### Fixed
+- when adding a product to the cart fails due to availability a proper error message is now shown to the customer
 
 ## [3.0.3] - 2024-12-20
 ### Fixed

--- a/extension/lib/ShopifyAdminApi.js
+++ b/extension/lib/ShopifyAdminApi.js
@@ -8,7 +8,7 @@ class ShopifyAdminApi {
    * @param {SDKContextLog} logger
    * @param {string?} apiVersion
    */
-  constructor (shopUrl, accessToken, logger, apiVersion = '2024-07') {
+  constructor (shopUrl, accessToken, logger, apiVersion = '2025-01') {
     this.apiUrl = new URL(`/admin/api/${apiVersion}/`, shopUrl).toString()
     this.accessToken = accessToken
     this.logger = logger

--- a/extension/lib/queries/addCartLines.js
+++ b/extension/lib/queries/addCartLines.js
@@ -5,6 +5,11 @@ mutation cartLinesAdd($cartId: ID!, $lines: [CartLineInput!]!) {
       field
       message
     }
+    warnings {
+      code
+      message
+      target
+    }
   }
 }
 `

--- a/extension/lib/queries/deleteCartLines.js
+++ b/extension/lib/queries/deleteCartLines.js
@@ -5,6 +5,11 @@ mutation cartLinesRemove($cartId: ID!, $lineIds: [ID!]!) {
       field
       message
     }
+    warnings {
+      code
+      message
+      target
+    }
   }
 }
 `

--- a/extension/lib/queries/updateCartBuyerIdentity.js
+++ b/extension/lib/queries/updateCartBuyerIdentity.js
@@ -5,6 +5,11 @@ mutation cartBuyerIdentityUpdate($cartId: ID!, $buyerIdentity: CartBuyerIdentity
             field
             message
         }
+        warnings {
+          code
+          message
+          target
+        }
     }
 }
 `

--- a/extension/lib/queries/updateCartLines.js
+++ b/extension/lib/queries/updateCartLines.js
@@ -5,6 +5,11 @@ mutation cartLinesUpdate($cartId: ID!, $lines: [CartLineUpdateInput!]!) {
       field
       message
     }
+    warnings {
+      code
+      message
+      target
+    }
   }
 }
 `

--- a/extension/typedefs.js
+++ b/extension/typedefs.js
@@ -153,6 +153,25 @@
  */
 
 /**
+ * @typedef ShopifyCartItemMutationResponseInternals
+ * @property {ShopifyCartItemMutationResponseUserError}[] userErrors
+ * @property {ShopifyCartItemMutationResponseWarning}[] warnings
+ */
+
+/**
+ * @typedef ShopifyCartItemMutationResponseUserError
+ * @property {string[]} fields
+ * @property {string} message
+ */
+
+/**
+ * @typedef ShopifyCartItemMutationResponseWarning
+ * @property {string} code
+ * @property {string} target
+ * @property {string} message
+ */
+
+/**
  * @typedef ShopgateCart
  * @property {boolean} isOrderable
  * @property {boolean|null} isTaxIncluded


### PR DESCRIPTION
# Pull Request Template

## Description

- update APIs to 2025-01 endpoints (Storefront & REST Admin)
- fix errors being swallowed when adding to cart from PDP failed

Storefront API introduces cart warnings in addition to the existing user errors and moves some former user errors to warnings. See for reference:
Old: https://shopify.dev/docs/api/storefront/2024-07/mutations/cartLinesAdd
New: https://shopify.dev/docs/api/storefront/2025-01/mutations/cartLinesAdd

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md